### PR TITLE
Add missing Finetuning scripts in GluonNLP

### DIFF
--- a/gluonnlp/logs/bert/finetuned_SNIPS.sh
+++ b/gluonnlp/logs/bert/finetuned_SNIPS.sh
@@ -1,0 +1,1 @@
+python3 finetune_icsl.py --gpu 0 --dataset snips

--- a/gluonnlp/logs/bert/finetuned_atis.sh
+++ b/gluonnlp/logs/bert/finetuned_atis.sh
@@ -1,0 +1,1 @@
+python3 finetune_icsl.py --gpu 0 --dataset atis

--- a/gluonnlp/logs/bert/finetuned_conll2003.sh
+++ b/gluonnlp/logs/bert/finetuned_conll2003.sh
@@ -1,0 +1,1 @@
+python3 finetune_ner.py  --train-path ${DATA_DIR}/train.txt --dev-path ${DATA_DIR}/dev.txt  --test-path ${DATA_DIR}/test.txt --gpu 0 --learning-rate 1e-5 --dropout-prob 0.1 --num-epochs 100 --batch-size 8 --optimizer bertadam --bert-model bert_24_1024_16 --save-checkpoint-prefix ${MODEL_DIR}/large_bert --seed 13531


### PR DESCRIPTION
`gluonnlp/logs/bert/finetuned_conll2003.sh` is to complement #182 
Two other scripts are new